### PR TITLE
fix: metrics percentage calculations missing *100

### DIFF
--- a/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
+++ b/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
@@ -437,7 +437,7 @@ Resources:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)'
+          Expression: 'm1/(m2+m3)*100'
           Label: SystemErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
@@ -487,7 +487,7 @@ Resources:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)'
+          Expression: 'm1/(m2+m3)*100'
           Label: GSISystemErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
@@ -543,7 +543,7 @@ Resources:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)'
+          Expression: 'm1/(m2+m3)*100'
           Label: UserErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
@@ -593,7 +593,7 @@ Resources:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)'
+          Expression: 'm1/(m2+m3)*100'
           Label: GSIUserErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:


### PR DESCRIPTION
Issue: https://github.com/aws-samples/amazon-dynamodb-monitoring/issues/2

Hello,

I am using this repo as a reference for creating DynamoDB alarms.

I found 4 alarms, which I think are not implemented correctly.
Those alarms are calculating percentage (%) of errors and if error percentage is over threshold, alarm will be raised.

Calculation (based on the first alarm in the PR - system errors):

`m1 = number_of_errors`
`m2 = number_of_consumed_read_capacity_units`
`m3 = number_of_consumed_write_capacity_units`

`expression = m1 / (m2 + m3)`

From this, it is clear that `0 <= expression <= 1.0`, but this is compared to `threshold = 2.0%`.

Please if you can reply and confirm that this is a bug (and merge this PR).
Or if I am not understanding this correctly, please explain what am I missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
