### PR TITLE
fix: Fix an alarm for `UserErrors`

### DIFF
--- a/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
+++ b/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
@@ -543,99 +543,20 @@ Resources:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)*100'
+          Expression: 'm1/(q1+m1)*100'
           Label: UserErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
             Metric:
               Namespace: 'AWS/DynamoDB'
               MetricName: 'UserErrors'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
             Period: 60 
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
-        - Id: 'm2'
-          MetricStat:
-            Metric:
-              Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedReadCapacityUnits'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
-            Period: 60 
-            Stat: 'SampleCount'
-            Unit: 'Count'
-          ReturnData: False
-        - Id: 'm3'
-          MetricStat:
-            Metric:
-              Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedWriteCapacityUnits'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
-            Period: 60 
-            Stat: 'SampleCount'
-            Unit: 'Count'
-          ReturnData: False
-      EvaluationPeriods: 2
-      Threshold: 2.0
-      ComparisonOperator: 'GreaterThanThreshold'
-  DynamoDBGSIUserErrorAlarm:
-    Type: 'AWS::CloudWatch::Alarm'
-    Properties:
-      AlarmName: 'DynamoDBGSIUserErrorAlarm'
-      AlarmDescription: 'Alarm when GSI user errors exceed 2% of total number of requests'
-      AlarmActions:
-        - !Ref DynamoDBMonitoringSNSTopic
-      Metrics:
-        - Id: 'e1'
-          Expression: 'm1/(m2+m3)*100'
-          Label: GSIUserErrorsOverTotalRequests
-        - Id: 'm1'
-          MetricStat:
-            Metric:
-              Namespace: 'AWS/DynamoDB'
-              MetricName: 'UserErrors'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
-            Stat: 'SampleCount'
-            Unit: 'Count'
-          ReturnData: False
-        - Id: 'm2'
-          MetricStat:
-            Metric:
-              Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedReadCapacityUnits'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
-            Stat: 'SampleCount'
-            Unit: 'Count'
-          ReturnData: False
-        - Id: 'm3'
-          MetricStat:
-            Metric:
-              Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedWriteCapacityUnits'
-              Dimensions:
-                - Name: 'TableName'
-                  Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
-            Stat: 'SampleCount'
-            Unit: 'Count'
+        - Id: 'q1'
+          Expression: 'SELECT COUNT(SuccessfulRequestLatency) FROM SCHEMA("AWS/DynamoDB", TableName, Operation)'
+          Period: 60 
           ReturnData: False
       EvaluationPeriods: 2
       Threshold: 2.0


### PR DESCRIPTION
This commit fixes the issue where an alarm for UserErrors does not work.

*Issue #, if available:*
Currently, `DynamoDBTableUserErrorAlarm` does not work. This pull request fixes this issue. The current implementation assumes that `UserErrors` has dimensions for `TableName` and `GlobalSecondaryIndexName`. However, `UserErrors` is an account level metric without `TableName` dimension.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html#UserErrors

*Description of changes:*
First, this pull request fixes incorrect expectations for `UserError`. This means we need to delete the alarm specifically for GSI. Additionally, we use [Metrics Insights CloudWatch alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-metrics-insights-alarm-create.html) to aggregate total numbers of requests in this implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
