### PR TITLE
fix: Fix an alarm for `SystemErrors`

### DIFF
--- a/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
+++ b/dynamodb_alarms_cf/dynamodb_alarms_cf.yaml
@@ -428,16 +428,16 @@ Resources:
       EvaluationPeriods: 2
       Threshold: 2.0
       ComparisonOperator: 'GreaterThanThreshold'
-  DynamoDBTableSystemErrorAlarm:
+  DynamoDBTableSystemErrorAlarmForRead:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
-      AlarmName: 'DynamoDBTableSystemErrorAlarm'
-      AlarmDescription: 'Alarm when system errors exceed 2% of total number of requests'
+      AlarmName: 'DynamoDBTableSystemErrorAlarmForRead'
+      AlarmDescription: 'Alarm when read system errors exceed 2% of total number of requests'
       AlarmActions:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)*100'
+          Expression: '(m1+m2+m3+m4)/(m1+m2+m3+m4+n1+n2+n3+n4)*100'
           Label: SystemErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
@@ -447,7 +447,9 @@ Resources:
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'GetItem'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
@@ -455,11 +457,13 @@ Resources:
           MetricStat:
             Metric:
               Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedReadCapacityUnits'
+              MetricName: 'SystemErrors'
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'BatchGetItem'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
@@ -467,28 +471,96 @@ Resources:
           MetricStat:
             Metric:
               Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedWriteCapacityUnits'
+              MetricName: 'SystemErrors'
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'Scan'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
-      EvaluationPeriods: 20
+        - Id: 'm4'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'Query'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'n1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'GetItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'BatchGetItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n3'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'Scan'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n4'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'Query'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+      EvaluationPeriods: 2
       Threshold: 2.0
       ComparisonOperator: 'GreaterThanThreshold'
-  DynamoDBGSISystemErrorAlarm:
+  DynamoDBTableSystemErrorAlarmForWrite:
     Type: 'AWS::CloudWatch::Alarm'
     Properties:
-      AlarmName: 'DynamoDBGSISystemErrorAlarm'
-      AlarmDescription: 'Alarm when GSI system errors exceed 2% of total number of requests'
+      AlarmName: 'DynamoDBTableSystemErrorAlarmForWrite'
+      AlarmDescription: 'Alarm when write system errors exceed 2% of total number of requests'
       AlarmActions:
         - !Ref DynamoDBMonitoringSNSTopic
       Metrics:
         - Id: 'e1'
-          Expression: 'm1/(m2+m3)*100'
-          Label: GSISystemErrorsOverTotalRequests
+          Expression: '(m1+m2+m3+m4)/(m1+m2+m3+m4+n1+n2+n3+n4)*100'
+          Label: SystemErrorsOverTotalRequests
         - Id: 'm1'
           MetricStat:
             Metric:
@@ -497,9 +569,9 @@ Resources:
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'PutItem'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
@@ -507,13 +579,13 @@ Resources:
           MetricStat:
             Metric:
               Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedReadCapacityUnits'
+              MetricName: 'SystemErrors'
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'DeleteItem'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
@@ -521,17 +593,246 @@ Resources:
           MetricStat:
             Metric:
               Namespace: 'AWS/DynamoDB'
-              MetricName: 'ConsumedWriteCapacityUnits'
+              MetricName: 'SystemErrors'
               Dimensions:
                 - Name: 'TableName'
                   Value: !Ref DynamoDBProvisionedTableName
-                - Name: 'GlobalSecondaryIndexName'
-                  Value: !Join [ '-', [!Ref DynamoDBProvisionedTableName, 'gsi1'] ]
-            Period: 60 
+                - Name: 'Operation'
+                  Value: 'UpdateItem'
+            Period: 60
             Stat: 'SampleCount'
             Unit: 'Count'
           ReturnData: False
-      EvaluationPeriods: 20
+        - Id: 'm4'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'BatchWriteItem'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'n1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'PutItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'DeleteItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n3'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'UpdateItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n4'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'BatchWriteItem'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+      EvaluationPeriods: 2
+      Threshold: 2.0
+      ComparisonOperator: 'GreaterThanThreshold'
+  DynamoDBTableSystemErrorAlarmForTransact:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: 'DynamoDBTableSystemErrorAlarmForTransact'
+      AlarmDescription: 'Alarm when transact system errors exceed 2% of total number of requests'
+      AlarmActions:
+        - !Ref DynamoDBMonitoringSNSTopic
+      Metrics:
+        - Id: 'e1'
+          Expression: '(m1+m2)/(m1+m2+n1+n2)*100'
+          Label: SystemErrorsOverTotalRequests
+        - Id: 'm1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'TransactWriteItems'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'm2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'TransactGetItems'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'n1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'TransactWriteItems'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'TransactGetItems'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+      EvaluationPeriods: 2
+      Threshold: 2.0
+      ComparisonOperator: 'GreaterThanThreshold'
+  DynamoDBTableSystemErrorAlarmForPartiQL:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: 'DynamoDBTableSystemErrorAlarmForPartiQL'
+      AlarmDescription: 'Alarm when PartiQL system errors exceed 2% of total number of requests'
+      AlarmActions:
+        - !Ref DynamoDBMonitoringSNSTopic
+      Metrics:
+        - Id: 'e1'
+          Expression: '(m1+m2+m3)/(m1+m2+m3+n1+n2+n3)*100'
+          Label: SystemErrorsOverTotalRequests
+        - Id: 'm1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'ExecuteTransaction'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'm2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'BatchExecuteStatement'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'm3'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SystemErrors'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'ExecuteStatement'
+            Period: 60
+            Stat: 'SampleCount'
+            Unit: 'Count'
+          ReturnData: False
+        - Id: 'n1'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'ExecuteTransaction'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n2'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'BatchExecuteStatement'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+        - Id: 'n3'
+          MetricStat:
+            Metric:
+              Namespace: 'AWS/DynamoDB'
+              MetricName: 'SuccessfulRequestLatency'
+              Dimensions:
+                - Name: 'TableName'
+                  Value: !Ref DynamoDBProvisionedTableName
+                - Name: 'Operation'
+                  Value: 'ExecuteStatement'
+            Period: 60
+            Stat: 'SampleCount'
+          ReturnData: False
+      EvaluationPeriods: 2
       Threshold: 2.0
       ComparisonOperator: 'GreaterThanThreshold'
   DynamoDBTableUserErrorAlarm:


### PR DESCRIPTION
This commit fixes the issue where an alarm for `SystemErrors` does not work.

*Issue #, if available:*
Currently, `DynamoDBTableSystemErrorAlarm` does not work. This pull request fixes this issue. The current implementation assumes that `SystemErrors` only has a dimension `TableName`. However, `SystemErrors` has an `Operation` dimension as well, which causes the alarm to never trigger when system errors occur.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html#SystemErrors

*Description of changes:*
This pull request includes several changes:

* Divide `DynamoDBTableSystemErrorAlarm` metrics into four different metrics: `DynamoDBTableSystemErrorAlarmForRead`, `DynamoDBTableSystemErrorAlarmForWrite`, `DynamoDBTableSystemErrorAlarmForTransact`, and `DynamoDBTableSystemErrorAlarmForPartiQL`. This addresses the limitation of CloudWatch Alarm which [limits the maximum number of metrics in an alarm to 10 metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html#:~:text=Alarms%20based%20on%20metric%20math%20expressions%20can%20have%20up%20to%2010%20metrics.). Additionally, splitting metrics enables users to determine the specific failure mode of DynamoDB more easily:
  - `DynamoDBTableSystemErrorAlarmForRead` covers `GetItem`, `BatchGetItem`, `Scan`, and `Query`.
  - `DynamoDBTableSystemErrorAlarmForWrite` covers `PutItem`, `DeleteItem`, `UpdateItem`, and `BatchWriteItem`.
  - `DynamoDBTableSystemErrorAlarmForTransact` covers `TransactWriteItems` and `TransactGetItems`.
  - `DynamoDBTableSystemErrorAlarmForPartiQL` covers `ExecuteTransaction`, `BatchExecuteStatement`, and `ExecuteStatement`.
* Use `SuccessfulRequestLatency (SampleCount)` instead of `ConsumedReadCapacityUnits (SampleCount)` and `ConsumedWriteCapacityUnits (SampleCount)`. We cannot count all requests by using `ConsumedReadCapacityUnits (SampleCount)` and `ConsumedWriteCapacityUnits　(SampleCount)`. They represent the frequency at which the metrics are emitted, not the actual number of requests. `SuccessfulRequestLatency (SampleCount)` is the appropriate metric to use for measuring the total number of successful requests.
* Change `EvaluationPeriods` from `20` to `2` to be consistent with other alarms in the codebase. All other similar alarms use `1` or `2` for this property, making error detection more responsive.

*Testing:*
I've verified these changes by confirming that `DynamoDBTableSystemErrorAlarmForWrite` properly calculates the metrics with correct dimensions. Since `SystemErrors` rarely occur in normal circumstances and DynamoDB is a managed service, I could not test the actual alarm triggering, but the mathematical expressions and metric configurations have been verified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
